### PR TITLE
feat(plugin): add detail to SimpleCompletionItem

### DIFF
--- a/src/renderer/plugins/editor-md-syntax.ts
+++ b/src/renderer/plugins/editor-md-syntax.ts
@@ -98,6 +98,7 @@ class MdSyntaxCompletionProvider implements Monaco.languages.CompletionItemProvi
         insertTextRules: this.monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
         range,
         sortText: i.toString().padStart(7),
+        detail: item.detail,
       }
     })
 

--- a/src/renderer/services/editor.ts
+++ b/src/renderer/services/editor.ts
@@ -18,6 +18,7 @@ export type SimpleCompletionItem = {
   label: string,
   kind?: Monaco.languages.CompletionItemKind,
   insertText: string,
+  detail?: string,
 }
 
 export type SimpleCompletionItemTappers = (items: SimpleCompletionItem[]) => void


### PR DESCRIPTION
通过 SimpleCompletionItem 透传 monaco-editor.languages.CompletionItem.detail 参数, 用于补全时提示补全文本, 效果如图:
![image](https://user-images.githubusercontent.com/36840659/229070179-d6d57625-443f-49ea-96d0-99168e1ea333.png)
