### PR TITLE
fix: support saving empty file

### DIFF
--- a/src/renderer/components/DefaultEditor.vue
+++ b/src/renderer/components/DefaultEditor.vue
@@ -58,10 +58,6 @@ export default defineComponent({
         return
       }
 
-      if (!currentContent.value) {
-        return
-      }
-
       if (file.repo === HELP_REPO_NAME) {
         return
       }


### PR DESCRIPTION
复现：当编辑器内容为空时，无法保存(ctrl+s)
原因：内容为空时，提前return
解决：删除判空逻辑

内容为空，无法保存 👇👇👇
![image](https://github.com/user-attachments/assets/8bd80d71-ed3a-4b10-887b-25a679601142)

内容不为空，可以保存  👇👇👇
![image](https://github.com/user-attachments/assets/1d761f76-f7fe-42d8-a2b8-6e35ec955233)
