### PR TITLE
Fix #459: failed to make New File and New Folder and show Error messa...

### DIFF
--- a/src/main/server/file.ts
+++ b/src/main/server/file.ts
@@ -226,8 +226,8 @@ export function write (repo: string, p: string, content: any): Promise<string> {
   if (readonly) throw new Error('Readonly')
 
   return withRepo(repo, async (_, filePath) => {
-    // create dir.
-    if (filePath.endsWith(path.sep)) {
+    // create dir. Check original path `p` because path.join() in withRepo strips trailing slashes.
+    if (p.endsWith('/') || filePath.endsWith(path.sep)) {
       await fs.ensureDir(filePath)
       return ''
     }


### PR DESCRIPTION
Closes #459

## Motivation

On Windows, `path.join()` called inside `withRepo` strips the trailing slash from directory paths before the trailing-separator check runs. This caused both "New File" and "New Folder" operations to fall through to the file-write branch, producing `ENOENT: no such file or directory` (for files) or silently doing nothing (for folders) because the target directory path was treated as a file path.

## Changes

**`src/main/server/file.ts` — `write` function (~line 229)**

The condition guarding `fs.ensureDir` previously only checked `filePath.endsWith(path.sep)`, where `filePath` is derived from `path.join()` and therefore never has a trailing separator. The fix adds a check on the *original* `p` parameter (before `withRepo` normalizes it) for a trailing `/`:

```ts
- if (filePath.endsWith(path.sep)) {
+ if (p.endsWith('/') || filePath.endsWith(path.sep)) {
```

The `p.endsWith('/')` check preserves the intent of the caller's signal (a trailing slash means "this is a directory") regardless of how `path.join` normalizes the path on any OS.

## Testing

- **Windows 11**: Create a new file and a new folder via the UI — both complete without error and appear in the file tree.
- **macOS/Linux**: Existing behavior is unchanged; `p.endsWith('/')` fires for directory paths on these platforms as well, making the fix consistent cross-platform.
- Verified that writing a normal file (path with no trailing slash) is unaffected — the condition remains `false` and execution continues to the file-write logic.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*